### PR TITLE
Support b and i tags in Basic HTML

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "SwiftHTMLtoMarkdown",
     platforms: [
-        .iOS(.v15),
+        .iOS(.v16),
         .macOS(.v13)
     ],
     products: [

--- a/Sources/SwiftHTMLtoMarkdown/BasicHTML.swift
+++ b/Sources/SwiftHTMLtoMarkdown/BasicHTML.swift
@@ -57,14 +57,14 @@ public class BasicHTML: HTML {
             let href = try node.attr("href")
             markdown += "(\(href))"
             return
-        } else if node.nodeName() == "strong" {
+        } else if node.nodeName() == "strong" || node.nodeName() == "b" {
             markdown += "**"
             for child in node.getChildNodes() {
                 try convertNode(child)
             }
             markdown += "**"
             return
-        } else if node.nodeName() == "em" {
+        } else if node.nodeName() == "em" || node.nodeName() == "i" {
             markdown += "*"
             for child in node.getChildNodes() {
                 try convertNode(child)

--- a/Tests/SwiftHTMLtoMarkdownTests/BasicHTMLTests.swift
+++ b/Tests/SwiftHTMLtoMarkdownTests/BasicHTMLTests.swift
@@ -20,11 +20,12 @@ final class BasicHTMLTests: XCTestCase {
         <h6>Heading level 6</h6>
         <p>I just love <strong>bold text</strong>.</p>
         
-        <p>Love<strong>is</strong>bold</p>
-        
+        <p>Love<b>is</b>bold</p>
+
         <p>Italicized text is the <em>cat's meow</em>.</p>
-        <p>A<em>cats</em>meow</p>
-        
+
+        <p>A<i>cats</i>meow</p>
+
         <p>This text is <em><strong>really important</strong></em>.</p>
         
         <p>This is some code <code>Hello World!</code></p>


### PR DESCRIPTION
The `<b>` and `<i>` tags are still quite common. This PR adds support for them to the BasicHTML parser.