### PR TITLE
Fix headline bug and add image support

### DIFF
--- a/Sources/SwiftHTMLtoMarkdown/BasicHTML.swift
+++ b/Sources/SwiftHTMLtoMarkdown/BasicHTML.swift
@@ -110,13 +110,13 @@ public class BasicHTML: HTML {
                 markdown += "\n```"
                 return
             }
-        }
-
-        if node.nodeName() == "#text" && node.description != " " {
-            markdown += node.description
-        }
-        
-        if node.nodeName() == "img" {
+        } else if node.nodeName() == "figcaption" {
+            markdown += "\n\n"
+            for child in node.getChildNodes() {
+                try convertNode(child)
+            }
+            markdown += "\n\n"
+        } else if node.nodeName() == "img" {
             markdown += "!["
             let alt = try node.attr("alt")
             markdown += alt
@@ -124,7 +124,18 @@ public class BasicHTML: HTML {
             let src = try node.attr("src")
             markdown += src
             markdown += ")"
+        } else if node.nodeName() == "div" {
+            if hasSpacedParagraph {
+                markdown += "\n\n"
+            } else {
+                hasSpacedParagraph = true
+            }
         }
+
+        if node.nodeName() == "#text" && node.description != " " {
+            markdown += node.description
+        }
+        
 
         for node in node.getChildNodes() {
             try convertNode(node)

--- a/Sources/SwiftHTMLtoMarkdown/BasicHTML.swift
+++ b/Sources/SwiftHTMLtoMarkdown/BasicHTML.swift
@@ -113,6 +113,16 @@ public class BasicHTML: HTML {
         if node.nodeName() == "#text" && node.description != " " {
             markdown += node.description
         }
+        
+        if node.nodeName() == "img" {
+            markdown += "!["
+            let alt = try node.attr("alt")
+            markdown += alt
+            markdown += "]("
+            let src = try node.attr("src")
+            markdown += src
+            markdown += ")"
+        }
 
         for node in node.getChildNodes() {
             try convertNode(node)

--- a/Sources/SwiftHTMLtoMarkdown/BasicHTML.swift
+++ b/Sources/SwiftHTMLtoMarkdown/BasicHTML.swift
@@ -22,6 +22,8 @@ public class BasicHTML: HTML {
                 return
             }
             
+            markdown += "\n\n"
+            
             for _ in 0..<level {
                 markdown += "#"
             }


### PR DESCRIPTION
- Add image tags support
- Add DIV tags support (will be tricked as general paragraph)
- Fix a problem with the lack of `\n\n` before the headline so that the headline may be rendered to the last paragraph

BTW. The Xcode 16.0 reports an error indicating that the `firstMatch(in: _)` function may not be available in lower than iOS 16 (`Sources/SwiftHTMLtoMarkdown/BasicHTML.swift:98`). I have no idea if it is a critical issue because I have no errors encountered when I use this library with network reference. The error appears when I clone the library to the local and import it as a local library.

Here is a suggested fix authored by Xcode:

<img width="784" alt="image" src="https://github.com/user-attachments/assets/1719fce2-bbf4-41fe-a0c9-517d8a43e7a1">
